### PR TITLE
Fix Makefile run rule indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ weights: clone
 	bash scripts/download_yolox_weights.sh
 
 run:
-        python tools/decoder-lite.py -f "$(EXP)" -c third_party/ByteTrack/pretrained/yolox_x.pth --path "$(FILE)" --save_result --device gpu --fp16 --keep-classes 0,32 --no-display $(EXTRA)
+	python tools/decoder-lite.py -f "$(EXP)" -c third_party/ByteTrack/pretrained/yolox_x.pth --path "$(FILE)" --save_result --device gpu --fp16 --keep-classes 0,32 --no-display $(EXTRA)
 
 test:
 	pytest -q


### PR DESCRIPTION
## Summary
- fix run target indentation in Makefile so other recipes parse

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02f2e163c832f96dc1f905d9b8496