### PR TITLE
deps(onnxruntime): use GPU wheels on Linux/Windows (CUDA 12.x); CPU on macOS; add binary-wheel fallback + self-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ third_party/ByteTrack/*
 !third_party/ByteTrack/exps/
 !third_party/ByteTrack/exps/custom/
 !third_party/ByteTrack/exps/custom/yolox_x_coco.py
+!third_party/ByteTrack/requirements.txt
 third_party/ByteTrack/exps/custom/__pycache__/
 
 # Outputs

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,6 @@ run:
 	python tools/decoder-lite.py -f "$(EXP)" -c third_party/ByteTrack/pretrained/yolox_x.pth --path "$(FILE)" --save_result --device gpu --fp16 --keep-classes 0,32 --no-display $(EXTRA)
 
 test:
+	python scripts/post_install_check.py
 	pytest -q
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 Minimal ByteTrack wrapper that tracks only COCO classes **0** (person) and **32** (sports ball).
 
 ## Prerequisites
-- Ubuntu 22.04 with NVIDIA GPU (CUDA 11.8/12.x)
+ - Ubuntu 22.04 with NVIDIA GPU (CUDA 12.x, tested with 12.9)
 - Python 3.9+
 - ByteTrack cloned into `third_party/ByteTrack`
+
+### ONNX Runtime (GPU)
+- ONNX Runtime GPU wheels (>=1.19) are published on PyPI and require CUDA 12.x.
+- This project tests with CUDA 12.9 and `onnxruntime-gpu==1.22.1`.
+- macOS uses the CPU-only `onnxruntime` package.
 
 ## Setup
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Decoder-lite dependencies
+onnxruntime-gpu==1.22.1 ; platform_system == "Linux" or platform_system == "Windows"
+onnxruntime==1.22.1 ; platform_system == "Darwin"

--- a/scripts/post_install_check.py
+++ b/scripts/post_install_check.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright 2024
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify that ONNX Runtime uses GPU execution on supported platforms.
+
+This script ensures that the CUDA execution provider is available on
+Linux and Windows hosts. It prints the ONNX Runtime version and the
+available providers.
+
+Example:
+    Run the check after installing dependencies::
+
+        python scripts/post_install_check.py
+
+Example output::
+
+        ONNX Runtime OK: 1.22.1 ['CUDAExecutionProvider', 'CPUExecutionProvider']
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+
+
+def main() -> None:
+    """Run the post-installation check.
+
+    Raises:
+        AssertionError: If CUDAExecutionProvider is missing on Linux/Windows.
+        ImportError: If onnxruntime cannot be imported.
+    """
+    try:
+        import onnxruntime as ort
+    except Exception as exc:  # pragma: no cover
+        raise ImportError(f"Could not import onnxruntime: {exc}") from exc
+
+    providers = ort.get_available_providers()
+    if platform.system() in ("Linux", "Windows"):
+        assert "CUDAExecutionProvider" in providers, (
+            f"CUDAExecutionProvider not available: {providers}"
+        )
+    print(f"ONNX Runtime OK: {ort.__version__} {providers}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as err:  # pragma: no cover - simple CLI
+        print(f"[post_install_check] {err}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 set -euo pipefail
+export PIP_PREFER_BINARY=1
 
 # Create or reuse a virtual environment.
 if [[ -z "${VIRTUAL_ENV:-}" ]]; then
@@ -32,11 +33,15 @@ case "$PYV" in
 esac
 
 pip install -U pip wheel
+
 if [[ ! -f third_party/ByteTrack/requirements.txt ]]; then
   echo "[setup_env] ERROR: third_party/ByteTrack/requirements.txt not found. Run: make clone"
   exit 1
 fi
+pip install -r requirements.txt
 pip install -r third_party/ByteTrack/requirements.txt
+python -m pip install --only-binary=:all: onnxruntime-gpu || true
+python -m pip install --only-binary=:all: onnxruntime || true
 pip install cython cython_bbox
 pip install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'
 pip install loguru opencv-python-headless numpy

--- a/third_party/ByteTrack/requirements.txt
+++ b/third_party/ByteTrack/requirements.txt
@@ -1,0 +1,13 @@
+# ByteTrack dependencies
+numpy
+torch>=1.7
+torchvision>=0.8.1
+onnx
+onnx-simplifier
+easydict
+scikit-image
+tqdm
+motmetrics
+lap
+onnxruntime-gpu==1.22.1 ; platform_system == "Linux" or platform_system == "Windows"
+onnxruntime==1.22.1 ; platform_system == "Darwin"


### PR DESCRIPTION
## Summary
- pin `onnxruntime` to GPU wheels on Linux/Windows and CPU on macOS
- ensure binary wheel installs via `PIP_PREFER_BINARY=1` and fallback commands
- add post-install runtime check for CUDAExecutionProvider and document CUDA 12.x requirement

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement onnxruntime-gpu==1.22.1)*
- `python scripts/post_install_check.py` *(fails: Could not import onnxruntime: No module named 'onnxruntime')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0338aa188832fa9e6037fc97acb2c