### PR TITLE
Install CPU onnxruntime only on fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Minimal ByteTrack wrapper that tracks only COCO classes **0** (person) and **32*
 ### ONNX Runtime
 - Linux/Windows use onnxruntime-gpu==1.22.0 (CUDA 12.x wheels).
 - macOS uses onnxruntime==1.22.1 (CPU).
+- `scripts/setup_env.sh` installs `onnxruntime-gpu` on Linux/Windows and
+  only falls back to the CPU wheel if the GPU wheel is unavailable.
 
 ## Setup
 ```bash

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -40,8 +40,15 @@ fi
 pip install -r requirements.txt
 pip install -r third_party/ByteTrack/requirements.txt
 export PIP_PREFER_BINARY=1
-python -m pip install --only-binary=:all: onnxruntime-gpu || true
-python -m pip install --only-binary=:all: onnxruntime || true
+if [[ "$(uname)" == "Darwin" ]]; then
+  # macOS uses the CPU-only wheel
+  python -m pip install --only-binary=:all: onnxruntime || true
+else
+  # Attempt GPU wheel; fall back to CPU if unavailable
+  if ! python -m pip install --only-binary=:all: onnxruntime-gpu; then
+    python -m pip install --only-binary=:all: onnxruntime || true
+  fi
+fi
 python - <<'PY'
 import platform, sys
 try:


### PR DESCRIPTION
## Summary
- Avoid overwriting GPU onnxruntime by falling back to CPU wheel only when GPU install fails or on macOS
- Document onnxruntime fallback logic in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0392df038832fa9879f1c35fef786