### PR TITLE
Ensure PyTorch is installed before ByteTrack build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,6 @@ Results are written to `outputs/videos/result.mp4` and logs to `outputs/logs/res
 
 ## Notes
 - Only COCO classes 0 and 32 are processed.
-- Torch with CUDA must already be installed in the environment.
+- Torch with CUDA must be present before building ByteTrack. `make venv` installs
+  PyTorch with CUDA 12.4 automatically; for other CUDA versions adjust the
+  index URL in `scripts/setup_env.sh`.


### PR DESCRIPTION
## Summary
- add setup script functions to install PyTorch for CUDA 12.4 and build ByteTrack in develop mode without build isolation
- update README with CUDA-specific PyTorch note

## Testing
- `make venv` *(fails: Cannot connect to proxy)*
- `python -c "import torch, yolox; print(torch.__version__, torch.version.cuda)"` *(fails: ModuleNotFoundError: No module named 'torch')*
- `make test` *(fails: Could not import onnxruntime: No module named 'onnxruntime')*


------
https://chatgpt.com/codex/tasks/task_e_68c045db32a0832f9c8d69d82f197e01