### PR TITLE
fix setup_env here-doc and add ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+# Copyright 2024
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt pytest
+      - name: Syntax check setup_env.sh
+        run: bash -n scripts/setup_env.sh
+      - name: Post-install check
+        run: python scripts/post_install_check.py
+      - name: Run tests
+        run: pytest -q

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -31,7 +31,7 @@ fi
 install_pytorch() {
   set -euo pipefail
   # 1) If torch already present, do nothing.
-  if python - <<'PY' 2>/dev/null; then
+  if python - <<'PY' 2>/dev/null
 import sys
 import torch  # noqa
 sys.exit(0)


### PR DESCRIPTION
## Summary
- fix setup_env.sh heredoc if syntax and ensure matching fi
- add CI workflow with bash syntax check for setup_env.sh

## Testing
- `bash -n scripts/setup_env.sh`
- `python scripts/post_install_check.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04e445414832fa2f7539d8c375005