### PR TITLE
feat: allow cpu-only ort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Syntax check setup_env.sh
         run: bash -n scripts/setup_env.sh
       - name: Post-install check
-        run: python scripts/post_install_check.py
+        run: ALLOW_CPU_ORT=1 python scripts/post_install_check.py
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- allow post-install check to skip GPU provider assertion on CPU-only setups
- set `ALLOW_CPU_ORT=1` in CI workflow

## Testing
- `python scripts/post_install_check.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0522725f0832fbb11702c386495e2