### PR TITLE
fix: handle class filtering for ByteTrack dets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ The Makefile adds `--no-display` for headless execution. Remove the flag to view
 
 Results are written to `outputs/videos/result.mp4` and logs to `outputs/logs/result.json`.
 
+Use the `--keep-classes` flag to restrict tracking to specific class IDs. If the
+detector outputs only five columns (no class column), the flag is ignored and a
+warning is logged.
+
 ## Notes
 - Only COCO classes 0 and 32 are processed.
 - Torch with CUDA must be present before building ByteTrack. `make venv` installs

--- a/tests/test_bytetrack_shapes.py
+++ b/tests/test_bytetrack_shapes.py
@@ -53,14 +53,11 @@ def test_bytetrack_shapes(cols: int) -> None:
     else:
         dets[0, 4] = 0.9
     img_info = {"ratio": 1.0, "height": 100, "width": 100}
+    dets[:, :4] /= img_info["ratio"]
 
-    dets_in, cls_col = normalize_dets(dets, img_info, {0, 32})
+    dets_in = normalize_dets(dets, {0, 32})
     tracker = DummyTracker()
     tracker.update(dets_in, [img_info["height"], img_info["width"]], (640, 640))
     assert tracker.calls == 1
     assert tracker.last_shape is not None
     assert tracker.last_shape[1] == 5
-    if cols >= 7:
-        assert cls_col is not None and cls_col.size == dets_in.shape[0]
-    else:
-        assert cls_col is None

--- a/tests/test_normalize_dets.py
+++ b/tests/test_normalize_dets.py
@@ -1,0 +1,63 @@
+# Copyright 2024
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import pathlib
+
+import numpy as np
+import pytest
+
+def _load_decoder_tool():
+    root = pathlib.Path(__file__).resolve().parents[1]
+    path = root / "tools" / "decoder-lite.py"
+    spec = importlib.util.spec_from_file_location("decoder_lite_tool", str(path))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+def test_filters_6col():
+    mod = _load_decoder_tool()
+    dets = np.array([
+        [0, 0, 10, 10, 0.90, 0],
+        [1, 1, 11, 11, 0.80, 1],
+        [2, 2, 12, 12, 0.70, 1],
+    ], dtype=np.float32)
+    out = mod.normalize_dets(dets, keep_classes=[1])
+    assert out.shape[1] == 5
+    assert out.shape[0] == 2
+    np.testing.assert_allclose(out[:, 4], [0.80, 0.70], rtol=1e-6, atol=1e-6)
+
+def test_filters_7col():
+    mod = _load_decoder_tool()
+    dets = np.array([
+        [0, 0, 10, 10, 0.95, 0.90, 0],
+        [1, 1, 11, 11, 0.85, 0.80, 1],
+        [2, 2, 12, 12, 0.75, 0.70, 0],
+    ], dtype=np.float32)
+    out = mod.normalize_dets(dets, keep_classes=[0])
+    assert out.shape[1] == 5
+    assert out.shape[0] == 2
+    np.testing.assert_allclose(out[:, 4], [0.95, 0.75], rtol=1e-6, atol=1e-6)
+
+def test_warns_5col(caplog: pytest.LogCaptureFixture):
+    mod = _load_decoder_tool()
+    dets = np.array([
+        [0, 0, 10, 10, 0.9],
+        [1, 1, 11, 11, 0.8],
+    ], dtype=np.float32)
+    with caplog.at_level(logging.WARNING):
+        out = mod.normalize_dets(dets, keep_classes=[0])
+    assert out.shape == (2, 5)
+    assert any("--keep-classes" in rec.message and "no class column" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- ensure `normalize_dets` filters classes for 5, 6, and 7+ column tensors and always output Nx5 for ByteTrack
- warn when `--keep-classes` is used on 5-column detections and note this in CLI help and README
- add unit tests covering 5-, 6-, and 7-column inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05541ca80832fb919f42a6a7ade75