### PR TITLE
Fix ByteTrack env setup for CUDA 12.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,11 @@ VENV_DIR := .venv
 PYTHON := $(VENV_DIR)/bin/python
 PIP := $(VENV_DIR)/bin/pip
 
-$(VENV_DIR):
-	python3 -m venv $(VENV_DIR)
-
 clone:
-	bash scripts/clone_bytetrack.sh
+        bash scripts/clone_bytetrack.sh
 
-venv: $(VENV_DIR)
-	. $(VENV_DIR)/bin/activate && bash scripts/setup_env.sh
+venv:
+        @bash scripts/setup_env.sh
 
 doctor:
 	. $(VENV_DIR)/bin/activate && $(PYTHON) scripts/doctor.py

--- a/README.md
+++ b/README.md
@@ -19,20 +19,26 @@ Minimal ByteTrack wrapper that tracks only COCO classes **0** (person) and **32*
 make venv      # this runs scripts/setup_env.sh
 make doctor    # verify torch/yolox/onnxruntime-gpu
 ```
+This repository vendors ByteTrack under `third_party/ByteTrack` (it is **not** a git submodule).
+The setup script:
+1. clones ByteTrack if missing,
+2. installs build tools and PyTorch (CUDA 12.1 wheels),
+3. installs ByteTrack in editable mode with `--no-build-isolation`,
+4. installs ONNX Runtime GPU `==1.22.0` plus `onnx` and `onnxsim`.
+
+> Notes:
+> * Do **not** use `--index-url` globally for PyTorch wheels — we use `--extra-index-url` so other packages come from PyPI.
+> * Avoid mixing CPU and GPU ONNX Runtime on the same platform.
+> * We do not modify any `third_party/ByteTrack/*.py` sources.
 
 ## Setup
 ```bash
-# optional: create and activate venv
-python -m venv .venv && source .venv/bin/activate
-
-# install dependencies and build ByteTrack
-make venv
+make venv      # create venv, clone ByteTrack, install deps
 
 # download YOLOX weights
 make weights
 ```
-`make venv` invokes `scripts/ensure_bytetrack.sh` which re-synchronizes the
-ByteTrack sources if they are incomplete before installing in develop mode.
+`make venv` executes `scripts/setup_env.sh` which clones and installs ByteTrack in editable mode.
 
 
 ## Usage
@@ -70,5 +76,5 @@ warning is logged.
 ## Notes
 - Only COCO classes 0 and 32 are processed.
 - Torch with CUDA must be present before building ByteTrack. `make venv` installs
-  PyTorch with CUDA 12.4 automatically; for other CUDA versions adjust the
-  index URL in `scripts/setup_env.sh`.
+  PyTorch with CUDA 12.1 wheels (compatible with CUDA 12.4 runtime); adjust the
+  index URL in `scripts/setup_env.sh` for other CUDA versions.

--- a/scripts/clone_bytetrack.sh
+++ b/scripts/clone_bytetrack.sh
@@ -9,38 +9,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Clone ByteTrack sources into third_party/ByteTrack.
+# Example usage:
+#   bash scripts/clone_bytetrack.sh
+# Example output:
+#   [clone_bytetrack] OK.
 
-# Clone ByteTrack into third_party/ByteTrack if missing.
 set -euo pipefail
 
-REPO_DIR="third_party/ByteTrack"
-# Офіційна інструкція радить клонувати ifzhang/ByteTrack (requirements.txt у корені).
-# Джерело: README ByteTrack — Step1. Install ByteTrack. (git clone https://github.com/ifzhang/ByteTrack.git)
-BYTETRACK_URL="${BYTETRACK_URL:-https://github.com/ifzhang/ByteTrack.git}"
-BYTETRACK_REV="${BYTETRACK_REV:-}"
-
-mkdir -p third_party
-if [[ -f "${REPO_DIR}/requirements.txt" ]]; then
-  echo "[clone_bytetrack] Found existing ${REPO_DIR} (requirements.txt present) — skipping clone."
+dst="third_party/ByteTrack"
+if [ -f "${dst}/yolox/__init__.py" ]; then
+  echo "[clone_bytetrack] ByteTrack already present."
   exit 0
 fi
 
-if [[ -d "${REPO_DIR}" ]]; then
-  echo "[clone_bytetrack] ${REPO_DIR} exists but no requirements.txt — removing and recloning..."
-  rm -rf "${REPO_DIR}"
-fi
+echo "[clone_bytetrack] Cloning ByteTrack sources…"
+rm -rf "${dst}"
+git clone --depth=1 https://github.com/FoundationVision/ByteTrack "${dst}"
 
-echo "[clone_bytetrack] Cloning ${BYTETRACK_URL} into ${REPO_DIR}..."
-git clone --depth 1 "${BYTETRACK_URL}" "${REPO_DIR}"
-if [[ -n "${BYTETRACK_REV}" ]]; then
-  echo "[clone_bytetrack] Checking out revision ${BYTETRACK_REV}..."
-  git -C "${REPO_DIR}" fetch --depth 1 origin "${BYTETRACK_REV}"
-  git -C "${REPO_DIR}" checkout -q "${BYTETRACK_REV}"
-fi
-
-if [[ ! -f "${REPO_DIR}/requirements.txt" ]]; then
-  echo "[clone_bytetrack] ERROR: requirements.txt not found in ${REPO_DIR}. Repository layout unexpected."
+if [ ! -f "${dst}/yolox/__init__.py" ]; then
+  echo "[clone_bytetrack] ERROR: yolox package not found after clone."
   exit 1
 fi
+echo "[clone_bytetrack] OK."
 
-echo "[clone_bytetrack] Done."


### PR DESCRIPTION
## Summary
- ensure setup_env.sh clones ByteTrack when missing
- install torch cu121, build deps, and ONNX Runtime GPU
- document that ByteTrack isn't a git submodule and `make venv` handles install

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c065b5e0b0832fa3d059fdcc659a1c