### PR TITLE
fix: robust ByteTrack editable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ warning is logged.
 
 ## Notes
 - Only COCO classes 0 and 32 are processed.
+- `scripts/setup_env.sh` removes stray `~ip` directories that can trigger
+  `pip` warnings about invalid distributions and reinstalls the build toolchain.
 - Torch with CUDA must be present before building ByteTrack. `make venv` installs
-  PyTorch with CUDA 12.1 wheels (compatible with CUDA 12.4 runtime); adjust the
+  PyTorch with CUDA 12.1 wheels (compatible with CUDA 12.4 runtime) and installs
+  ByteTrack in PEP 517 editable compat mode without dependencies; adjust the
   index URL in `scripts/setup_env.sh` for other CUDA versions.


### PR DESCRIPTION
## Summary
- clean pip `~ip` artifacts and reinstall build tools
- install ByteTrack in PEP 517 compat mode without deps
- document cleanup and ByteTrack install requirement

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c075a886a0832fb0aa682d4a094986