### PR TITLE
chore: extend ByteTrack deps and Timer fallback

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -85,7 +85,17 @@ python scripts/verify_torchvision_nms.py --quiet || {
 # 5) Install runtime dependencies for ByteTrack (avoid requirements.txt)
 if [[ "${MODE}" != "--vision-only" ]]; then
   echo "[setup_env] Installing runtime dependencies for ByteTrack ..."
-  python -m pip install -U "numpy<2.3" opencv-python loguru "easydict>=1.10" "scikit-image<0.25" thop motmetrics
+  python -m pip install -U \
+    "numpy<2.3" \
+    opencv-python \
+    loguru \
+    "easydict>=1.10" \
+    "scikit-image<0.25" \
+    thop \
+    motmetrics \
+    tabulate \
+    tqdm \
+    pycocotools
   # Try to install the faster 'lap'; fall back to 'lapx' if wheels are missing
   python -m pip install lap || python -m pip install lapx
   echo "[setup_env] Installing ByteTrack in editable mode ..."

--- a/tools/decoder-lite.py
+++ b/tools/decoder-lite.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+import time
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence, Set
 
@@ -198,7 +200,21 @@ def main() -> None:
     from yolox.utils import fuse_model, get_model_info, postprocess
     from yolox.data.data_augment import preproc
     from yolox.utils.visualize import plot_tracking
-    from yolox.utils import Timer
+    try:
+        # Старі гілки YOLOX мали Timer у yolox.utils; якщо є — використовуємо.
+        from yolox.utils import Timer  # type: ignore
+    except Exception:
+        # Фолбек-сумісність: простий таймер з tic()/toc() для логування/замірів.
+        class Timer:
+            def __init__(self) -> None:
+                self._t0: Optional[float] = None
+
+            def tic(self) -> None:
+                self._t0 = time.perf_counter()
+
+            def toc(self) -> float:
+                t0 = self._t0 or time.perf_counter()
+                return time.perf_counter() - t0
     from yolox.tracker.byte_tracker import BYTETracker
     import cv2
     import torch


### PR DESCRIPTION
## Summary
- ensure setup_env.sh installs tabulate, tqdm, pycocotools along with ByteTrack runtime dependencies
- add Timer fallback to decoder-lite to avoid ImportError on YOLOX utils

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c081e0a624832f863e2a1bd8a0f8b3