### PR TITLE
Add cython-bbox dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,5 @@ warning is logged.
   PyTorch with CUDA 12.1 wheels (compatible with CUDA 12.4 runtime) and installs
   ByteTrack in PEP 517 editable compat mode without dependencies; adjust the
   index URL in `scripts/setup_env.sh` for other CUDA versions.
+- The setup script installs `cython-bbox`, required for bounding box overlap
+  computations in ByteTrack.

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -95,7 +95,8 @@ if [[ "${MODE}" != "--vision-only" ]]; then
     motmetrics \
     tabulate \
     tqdm \
-    pycocotools
+    pycocotools \
+    cython-bbox
   # Try to install the faster 'lap'; fall back to 'lapx' if wheels are missing
   python -m pip install lap || python -m pip install lapx
   echo "[setup_env] Installing ByteTrack in editable mode ..."


### PR DESCRIPTION
## Summary
- install `cython-bbox` during environment setup
- document `cython-bbox` requirement in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c082f2a20c832fac511dbf57ec256d