### PR TITLE
Add NumPy 2 compatibility shim for ByteTrack

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ We never modify files under `third_party/ByteTrack/`. If the folder is missing o
 > * If you need to re-run only the Torch/Torchvision setup, call:
 >   `bash scripts/setup_env.sh --vision-only` (this skips cloning/ByteTrack deps).
 > * We do not modify any `third_party/ByteTrack/*.py` sources.
+> * Runtime `sitecustomize.py` restores `np.float`, `np.int`, `np.bool`, and
+>   `np.object` so ByteTrack works with NumPy 2.x without modifying vendor code.
 
 ## Setup
 ```bash

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,46 @@
+# Copyright 2024 decoder-lite contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""NumPy 2.x compatibility shim for legacy aliases used by third-party code.
+
+This module restores aliases such as ``np.float`` removed in NumPy 2.x. It is
+loaded automatically by Python when this repository root is on ``sys.path``.
+
+Example:
+    Running ``python tools/decoder-lite.py --help`` should no longer raise
+    ``AttributeError: module 'numpy' has no attribute 'float'``.
+
+Example output::
+
+    $ python tools/decoder-lite.py --help
+    usage: decoder-lite.py [-h] [--video VIDEO] [...]
+"""
+
+from __future__ import annotations
+
+try:
+    import numpy as _np
+
+    # Restore removed aliases to keep older code paths working.
+    if not hasattr(_np, "float"):
+        _np.float = float
+    if not hasattr(_np, "int"):
+        _np.int = int
+    if not hasattr(_np, "bool"):
+        _np.bool = bool
+    if not hasattr(_np, "object"):
+        _np.object = object
+except Exception:  # pragma: no cover - never fail hard from sitecustomize
+    # The environment should remain usable even if NumPy is missing or
+    # partially installed, so swallow all exceptions.
+    pass

--- a/tests/test_sitecustomize.py
+++ b/tests/test_sitecustomize.py
@@ -1,0 +1,36 @@
+# Copyright 2024 decoder-lite contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`sitecustomize` NumPy alias restoration."""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+import numpy as np
+
+
+def test_numpy_aliases_restored() -> None:
+    """Ensure legacy NumPy aliases are present after importing sitecustomize."""
+    # Ensure repository root is on sys.path so `sitecustomize` can be imported
+    # even if Python started elsewhere (e.g., when invoking pytest).
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root))
+    importlib.import_module("sitecustomize")
+
+    assert hasattr(np, "float")
+    assert hasattr(np, "int")
+    assert hasattr(np, "bool")
+    assert hasattr(np, "object")


### PR DESCRIPTION
## Summary
- add `sitecustomize.py` to restore removed NumPy aliases (`np.float`, etc.)
- document shim in README
- test legacy alias restoration

## Testing
- `python tools/decoder-lite.py --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12e38560c832fad9b544493f7a941