### PR TITLE
Add robust FPS measurement with EMA smoothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ warning is logged.
 
 ## Notes
 - Only COCO classes 0 and 32 are processed.
+- FPS is smoothed with an exponential moving average and falls back to
+  ``time.perf_counter`` if the ByteTrack timer lacks ``toc``.
 - Inference always runs in FP32; any `--fp16` flag is ignored and the launcher logs `Using FP32 inference (fp16 disabled)`.
 - Experiments lacking `rgb_means`/`std` fall back to ImageNet values `(0.485, 0.456, 0.406)` and `(0.229, 0.224, 0.225)`.
 - The tracker automatically detects old/new ByteTrack APIs and adapts the `BYTETracker`

--- a/tests/test_decoder_lite.py
+++ b/tests/test_decoder_lite.py
@@ -28,6 +28,7 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
 parse_keep = MODULE.parse_keep
 filter_by_classes = MODULE.filter_by_classes
+FpsEMA = MODULE.FpsEMA
 
 
 def test_make_parser_fp16_flag() -> None:
@@ -53,6 +54,14 @@ def test_filter_by_classes() -> None:
     filtered = filter_by_classes(dets, keep)
     assert filtered.shape[0] == 2
     assert set(filtered[:, 5].astype(int)) == {0, 32}
+
+
+def test_fps_ema() -> None:
+    meter = FpsEMA(alpha=0.5)
+    assert meter.update(0.2) == 5.0
+    assert meter.update(0.1) == pytest.approx(7.5)
+    # Negative or zero dt should keep previous FPS
+    assert meter.update(0.0) == pytest.approx(7.5)
 
 
 def test_predictor_mean_std_defaults() -> None:


### PR DESCRIPTION
## Summary
- add `FpsEMA` helper for stable FPS calculation
- compute FPS from timer.toc() or perf_counter fallback to avoid missing attributes
- document EMA-based FPS smoothing in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c12fc27200832f8527360f34ddfdb1