### PR TITLE
Add option to save raw frames without overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Additional flags can be passed through `EXTRA`, for example:
 make run FILE=video.mp4 EXTRA="--fuse"
 ```
 
+To save raw frames without overlays, combine `--save_result` and `--save-raw`:
+
+```bash
+make run FILE=video.mp4 EXTRA="--save_result --save-raw"
+```
+
 The Makefile adds `--no-display` for headless execution. Remove the flag to view a window.
 
 Results are written to `outputs/videos/result.mp4` and logs to `outputs/logs/result.json`.

--- a/tests/test_decoder_lite.py
+++ b/tests/test_decoder_lite.py
@@ -41,6 +41,12 @@ def test_make_parser_fp16_flag() -> None:
     assert args.fp16 is True
 
 
+def test_save_raw_flag() -> None:
+    parser = MODULE.make_parser()
+    args = parser.parse_args(["-f", "exp.py", "-c", "weights.pth", "--save-raw"])
+    assert args.save_raw is True
+
+
 def test_parse_keep() -> None:
     assert parse_keep("0,32") == [0, 32]
     assert parse_keep("32,0,0") == [0, 32]


### PR DESCRIPTION
## Summary
- add `--save-raw` flag to write unannotated frames
- respect `--save-raw` when displaying or saving video
- document raw saving workflow and test flag parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c14c7f20e8832f94a93b4ac04e54cc