### PR TITLE
Fix frame rendering logic

### DIFF
--- a/tools/decoder-lite.py
+++ b/tools/decoder-lite.py
@@ -449,22 +449,26 @@ def main() -> None:
                         _prev_ts = _now
                     _fps = fps_meter.update(_dt)
                     fps = float(_fps) if _fps is not None else 0.0
-                    # Preserve the original frame before drawing overlays.
-                    raw_im = img_info["raw_img"].copy()
-                    # Draw on a separate buffer to avoid mutating ``raw_im``.
-                    vis_im = raw_im.copy()
-                    annotated = call_with_supported_kwargs(
-                        plot_tracking,
-                        vis_im,
-                        online_tlwhs,
-                        online_ids,
-                        scores=online_scores,
-                        frame_id=frame_id,
-                        fps=fps,
-                        cls_ids=online_cls_ids if "online_cls_ids" in locals() else None,
-                    )
+                    raw_im = img_info["raw_img"]
+                    should_draw = args.save_result or (not args.no_display)
+                    vis_im = raw_im
+                    if should_draw:
+                        draw_src = raw_im.copy()
+                        vis_im = call_with_supported_kwargs(
+                            plot_tracking,
+                            draw_src,
+                            online_tlwhs,
+                            online_ids,
+                            scores=online_scores,
+                            frame_id=frame_id,
+                            fps=fps,
+                            cls_ids=online_cls_ids if "online_cls_ids" in locals() else None,
+                        )
                     if args.save_result:
-                        writer.write(raw_im if args.save_raw else annotated)
+                        frame_to_write = (
+                            raw_im if getattr(args, "save_raw", False) else vis_im
+                        )
+                        writer.write(frame_to_write)
                         record = {
                             "frame": int(frame_id),
                             "tlwh": [
@@ -475,9 +479,7 @@ def main() -> None:
                         }
                         records.append(record)
                     if not args.no_display:
-                        cv2.imshow(
-                            "ByteTrack", raw_im if args.save_raw else annotated
-                        )
+                        cv2.imshow("ByteTrack", vis_im)
                 else:
                     _dt = None
                     _toc = getattr(timer, "toc", None)
@@ -492,23 +494,27 @@ def main() -> None:
                         _prev_ts = _now
                     _fps = fps_meter.update(_dt)
                     fps = float(_fps) if _fps is not None else 0.0
-                    raw_im = img_info["raw_img"].copy()
-                    vis_im = raw_im.copy()
-                    annotated = call_with_supported_kwargs(
-                        plot_tracking,
-                        vis_im,
-                        [],
-                        [],
-                        scores=[],
-                        frame_id=frame_id,
-                        fps=fps,
-                    )
-                    if args.save_result:
-                        writer.write(raw_im if args.save_raw else annotated)
-                    if not args.no_display:
-                        cv2.imshow(
-                            "ByteTrack", raw_im if args.save_raw else annotated
+                    raw_im = img_info["raw_img"]
+                    should_draw = args.save_result or (not args.no_display)
+                    vis_im = raw_im
+                    if should_draw:
+                        draw_src = raw_im.copy()
+                        vis_im = call_with_supported_kwargs(
+                            plot_tracking,
+                            draw_src,
+                            [],
+                            [],
+                            scores=[],
+                            frame_id=frame_id,
+                            fps=fps,
                         )
+                    if args.save_result:
+                        frame_to_write = (
+                            raw_im if getattr(args, "save_raw", False) else vis_im
+                        )
+                        writer.write(frame_to_write)
+                    if not args.no_display:
+                        cv2.imshow("ByteTrack", vis_im)
             else:
                 _dt = None
                 _toc = getattr(timer, "toc", None)
@@ -523,23 +529,27 @@ def main() -> None:
                     _prev_ts = _now
                 _fps = fps_meter.update(_dt)
                 fps = float(_fps) if _fps is not None else 0.0
-                raw_im = img_info["raw_img"].copy()
-                vis_im = raw_im.copy()
-                annotated = call_with_supported_kwargs(
-                    plot_tracking,
-                    vis_im,
-                    [],
-                    [],
-                    scores=[],
-                    frame_id=frame_id,
-                    fps=fps,
-                )
-                if args.save_result:
-                    writer.write(raw_im if args.save_raw else annotated)
-                if not args.no_display:
-                    cv2.imshow(
-                        "ByteTrack", raw_im if args.save_raw else annotated
+                raw_im = img_info["raw_img"]
+                should_draw = args.save_result or (not args.no_display)
+                vis_im = raw_im
+                if should_draw:
+                    draw_src = raw_im.copy()
+                    vis_im = call_with_supported_kwargs(
+                        plot_tracking,
+                        draw_src,
+                        [],
+                        [],
+                        scores=[],
+                        frame_id=frame_id,
+                        fps=fps,
                     )
+                if args.save_result:
+                    frame_to_write = (
+                        raw_im if getattr(args, "save_raw", False) else vis_im
+                    )
+                    writer.write(frame_to_write)
+                if not args.no_display:
+                    cv2.imshow("ByteTrack", vis_im)
         else:
             _dt = None
             _toc = getattr(timer, "toc", None)
@@ -554,23 +564,27 @@ def main() -> None:
                 _prev_ts = _now
             _fps = fps_meter.update(_dt)
             fps = float(_fps) if _fps is not None else 0.0
-            raw_im = img_info["raw_img"].copy()
-            vis_im = raw_im.copy()
-            annotated = call_with_supported_kwargs(
-                plot_tracking,
-                vis_im,
-                [],
-                [],
-                scores=[],
-                frame_id=frame_id,
-                fps=fps,
-            )
-            if args.save_result:
-                writer.write(raw_im if args.save_raw else annotated)
-            if not args.no_display:
-                cv2.imshow(
-                    "ByteTrack", raw_im if args.save_raw else annotated
+            raw_im = img_info["raw_img"]
+            should_draw = args.save_result or (not args.no_display)
+            vis_im = raw_im
+            if should_draw:
+                draw_src = raw_im.copy()
+                vis_im = call_with_supported_kwargs(
+                    plot_tracking,
+                    draw_src,
+                    [],
+                    [],
+                    scores=[],
+                    frame_id=frame_id,
+                    fps=fps,
                 )
+            if args.save_result:
+                frame_to_write = (
+                    raw_im if getattr(args, "save_raw", False) else vis_im
+                )
+                writer.write(frame_to_write)
+            if not args.no_display:
+                cv2.imshow("ByteTrack", vis_im)
         if not args.no_display and cv2.waitKey(1) == 27:
             break
     cap.release()


### PR DESCRIPTION
## Summary
- prevent raw frame mutation when drawing tracking overlays
- draw overlays when saving results even with `--no-display`
- streamline saving and display logic using a single `vis_im` buffer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15f893dac832fbd145e1d4b9c7363