### PR TITLE
Refactor ByteTrack visualization buffer and saving logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ make run FILE=video.mp4 EXTRA="--save_result --save-raw"
 
 The Makefile adds `--no-display` for headless execution. Remove the flag to view a window.
 
-Results are written to `outputs/videos/result.mp4` and logs to `outputs/logs/result.json`.
+Frames are always annotated in memory. Display happens only when a screen is
+available, but the video file always receives the annotated frames unless
+`--save-raw` is specified. Results are written to `outputs/videos/result.mp4`
+and logs to `outputs/logs/result.json`.
 
 Use the `--keep-classes` flag to restrict tracking to specific class IDs. If the
 detector outputs only five columns (no class column), the flag is ignored and a


### PR DESCRIPTION
## Summary
- Unify visualization pipeline to draw tracking overlays on a copy of the raw frame
- Save either annotated or raw frames via a single writer path and update README docs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16873f3a4832f8bb1ae5974a39570