### PR TITLE
Handle 5/6-column detections in ByteTrack wrapper

### DIFF
--- a/tests/test_bytetrack_shapes.py
+++ b/tests/test_bytetrack_shapes.py
@@ -45,11 +45,11 @@ class DummyTracker:
 
 
 @pytest.mark.skipif(np is None, reason="numpy not available")
-@pytest.mark.parametrize("cols", [7, 5])
+@pytest.mark.parametrize("cols", [6, 5])
 def test_bytetrack_shapes(cols: int) -> None:
     dets = np.zeros((1, cols), dtype=float)
-    if cols >= 7:
-        dets[0, 4:7] = [0.9, 0.8, 0]
+    if cols == 6:
+        dets[0, 4:6] = [0.9, 0]
     else:
         dets[0, 4] = 0.9
     img_info = {"ratio": 1.0, "height": 100, "width": 100}


### PR DESCRIPTION
## Summary
- normalize detections in both 5- and 6-column formats, ignoring class filters when no class column
- log per-frame detection counts and add runtime checks for detection shape/coordinates
- cover new detection formats in unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1729100c4832f87a8adc56bf8046d