### PR TITLE
Support YOLOX 7-column detections

### DIFF
--- a/tests/test_bytetrack_shapes.py
+++ b/tests/test_bytetrack_shapes.py
@@ -45,11 +45,13 @@ class DummyTracker:
 
 
 @pytest.mark.skipif(np is None, reason="numpy not available")
-@pytest.mark.parametrize("cols", [6, 5])
+@pytest.mark.parametrize("cols", [6, 5, 7])
 def test_bytetrack_shapes(cols: int) -> None:
     dets = np.zeros((1, cols), dtype=float)
     if cols == 6:
         dets[0, 4:6] = [0.9, 0]
+    elif cols == 7:
+        dets[0, 4:7] = [0.9, 0.8, 0]
     else:
         dets[0, 4] = 0.9
     img_info = {"ratio": 1.0, "height": 100, "width": 100}

--- a/tests/test_normalize_dets.py
+++ b/tests/test_normalize_dets.py
@@ -41,7 +41,7 @@ def test_filters_6col():
 
 def test_invalid_shape_raises():
     mod = _load_decoder_tool()
-    dets = np.zeros((1, 7), dtype=np.float32)
+    dets = np.zeros((1, 8), dtype=np.float32)
     with pytest.raises(ValueError):
         mod.normalize_dets(dets, keep_classes={0})
 
@@ -57,3 +57,17 @@ def test_warns_5col_once(caplog: pytest.LogCaptureFixture):
         mod.normalize_dets(dets, keep_classes={0})
     msgs = [rec.message for rec in caplog.records if "Ignoring --keep-classes" in rec.message]
     assert len(msgs) == 1
+
+
+def test_yolox_7col():
+    mod = _load_decoder_tool()
+    dets = np.array(
+        [
+            [0, 0, 10, 10, 0.9, 0.8, 1],
+            [1, 1, 11, 11, 0.5, 0.4, 2],
+        ],
+        dtype=np.float32,
+    )
+    out = mod.normalize_dets(dets, keep_classes={1})
+    assert out.shape == (1, 5)
+    np.testing.assert_allclose(out[:, 4], [0.72], rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## Summary
- handle YOLOX-style outputs in `normalize_dets` by combining object and class confidences
- log detection array shape after coordinate rescaling
- extend tests for 7-column detections and maintain shape expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c17511c70c832f86b5c561724e1901