### PR TITLE
Normalize empty detections to ByteTrack's expected shape

### DIFF
--- a/tests/test_bytetrack_shapes.py
+++ b/tests/test_bytetrack_shapes.py
@@ -63,3 +63,16 @@ def test_bytetrack_shapes(cols: int) -> None:
     assert tracker.calls == 1
     assert tracker.last_shape is not None
     assert tracker.last_shape[1] == 5
+
+
+@pytest.mark.skipif(np is None, reason="numpy not available")
+@pytest.mark.parametrize("cols", [6, 5, 7])
+def test_bytetrack_empty_shapes(cols: int) -> None:
+    dets = np.empty((0, cols), dtype=float)
+    img_info = {"ratio": 1.0, "height": 100, "width": 100}
+    dets[:, :4] /= img_info["ratio"]
+    dets_in, _ = normalize_dets(dets, {0, 32})
+    tracker = DummyTracker()
+    tracker.update(dets_in, [img_info["height"], img_info["width"]], (640, 640))
+    assert tracker.calls == 1
+    assert tracker.last_shape == (0, 5)

--- a/tests/test_normalize_dets.py
+++ b/tests/test_normalize_dets.py
@@ -95,3 +95,13 @@ def test_soft_filter_warns(caplog: pytest.LogCaptureFixture) -> None:
     assert cls is not None and cls.tolist() == [1, 1]
     msgs = [rec.message for rec in caplog.records if "Class filter kept 0/" in rec.message]
     assert len(msgs) == 1
+
+
+@pytest.mark.parametrize("cols", [5, 6, 7])
+def test_empty_inputs_return_canonical_shape(cols: int) -> None:
+    mod = _load_decoder_tool()
+    dets = np.empty((0, cols), dtype=np.float32)
+    out, cls = mod.normalize_dets(dets, keep_classes={0})
+    assert out.shape == (0, 5)
+    assert out.dtype == np.float32
+    assert cls is None

--- a/tools/decoder-lite.py
+++ b/tools/decoder-lite.py
@@ -202,7 +202,8 @@ def normalize_dets(
     """
 
     if dets.size == 0:
-        return dets, None
+        empty = np.empty((0, 5), dtype=np.float32)
+        return empty, None
 
     cols = dets.shape[1]
 


### PR DESCRIPTION
## Summary
- normalize_dets now returns an explicit (0,5) array for empty inputs
- add tests covering empty detection arrays and ByteTrack integration

## Testing
- `python scripts/post_install_check.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17d86435c832f88e7f3c76ae47b3c