### PR TITLE
Handle empty keep-classes and align detection pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ EXTRA ?=
 WEIGHTS ?= third_party/ByteTrack/pretrained/yolox_x.pth
 
 # Enforce FP32 by default; no --fp16 flag is present in the run arguments.
-RUN_ARGS ?= --save_result --device gpu --keep-classes 0,32 --no-display
+RUN_ARGS ?= --save_result --device gpu --no-display
 
 VENV_DIR := .venv
 PYTHON := $(VENV_DIR)/bin/python

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # decoder-lite
 
-Minimal ByteTrack wrapper that tracks only COCO classes **0** (person) and **32** (sports ball).
+Minimal ByteTrack wrapper with optional COCO class filtering.
 
 ## Prerequisites
 - Ubuntu 22.04 with NVIDIA GPU (CUDA 12.x, tested with 12.9)
@@ -92,16 +92,16 @@ and IDs. With `--save_result` the annotated frames are written to
 `outputs/videos/result.mp4`. Pass `--save-raw` to store unmodified frames
 instead. JSON logs are written to `outputs/logs/result.json`.
 
-Use the `--keep-classes` flag to restrict tracking to specific class IDs. If the
-detector outputs only five columns (no class column), the flag is ignored and a
-warning is logged. YOLOX detections with five, six, or seven columns are
-supported; for the seven-column variant the final score is ``obj_conf *
-cls_conf``. Class filtering is "soft": if the filter removes all detections in a
-frame, it is disabled for that frame and a warning is emitted so visualization
-is preserved.
+Use the `--keep-classes` flag to restrict tracking to specific COCO class IDs
+(``--keep-classes 0,32`` for persons and sports balls). Passing no value or an
+empty string disables filtering. If the detector outputs only five columns (no
+class column), the flag is ignored and a warning is logged. YOLOX detections
+with five, six, or seven columns are supported; for the seven-column variant the
+final score is ``obj_conf * cls_conf``. Class filtering is "soft": if the filter
+removes all detections in a frame, it is disabled for that frame and a warning
+is emitted so visualization is preserved.
 
 ## Notes
-- Only COCO classes 0 and 32 are processed.
 - FPS is smoothed with an exponential moving average and falls back to
   ``time.perf_counter`` if the ByteTrack timer lacks ``toc``.
 - Inference always runs in FP32; any `--fp16` flag is ignored and the launcher logs `Using FP32 inference (fp16 disabled)`.

--- a/tests/test_decoder_lite.py
+++ b/tests/test_decoder_lite.py
@@ -29,7 +29,7 @@ SPEC = importlib.util.spec_from_file_location(
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
-parse_keep = MODULE.parse_keep
+parse_keep_classes = MODULE.parse_keep_classes
 filter_by_classes = MODULE.filter_by_classes
 FpsEMA = MODULE.FpsEMA
 call_with_supported_kwargs = MODULE.call_with_supported_kwargs
@@ -47,10 +47,10 @@ def test_save_raw_flag() -> None:
     assert args.save_raw is True
 
 
-def test_parse_keep() -> None:
-    assert parse_keep("0,32") == [0, 32]
-    assert parse_keep("32,0,0") == [0, 32]
-    assert parse_keep("") == []
+def test_parse_keep_classes() -> None:
+    assert parse_keep_classes("0,32") == [0, 32]
+    assert parse_keep_classes("") is None
+    assert parse_keep_classes(None) is None
 
 
 @pytest.mark.skipif(np is None, reason="numpy not available")


### PR DESCRIPTION
## Summary
- parse `--keep-classes` as optional list and treat empty input as disabling filtering
- align detection pipeline with ByteTrack: rescale before filtering, preserve canonical empty detections, and run tracker on `[x1,y1,x2,y2,score]`
- ensure raw frame saving leaves overlays out and document new CLI behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1814bb4e4832fa66f9677cd7609d5